### PR TITLE
feat: add beta indicator and feedback widget

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -5,6 +5,7 @@
     "rewrites": [
       { "source": "/api/validate", "function": "validate" },
       { "source": "/api/fix", "function": "fix" },
+      { "source": "/api/feedback", "function": "feedback" },
       { "source": "/models", "destination": "/models.html" },
       { "source": "/why", "destination": "/why.html" }
     ]

--- a/packages/backend/.env.sample
+++ b/packages/backend/.env.sample
@@ -2,3 +2,6 @@
 OPENAI_API_KEY=
 GOOGLE_GENERATIVE_AI_API_KEY=
 ANTHROPIC_API_KEY=
+
+# GitHub PAT for feedback → GitHub Issues integration
+GITHUB_PAT=

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -12,6 +12,7 @@ const IS_EMULATOR = process.env.FUNCTIONS_EMULATOR === "true";
 const OPENAI_API_KEY_SECRET = defineSecret("OPENAI_API_KEY");
 const GOOGLE_GENERATIVE_AI_API_KEY_SECRET = defineSecret("GOOGLE_GENERATIVE_AI_API_KEY");
 const ANTHROPIC_API_KEY_SECRET = defineSecret("ANTHROPIC_API_KEY");
+const GITHUB_PAT_SECRET = defineSecret("GITHUB_PAT");
 
 function getApiKeys(): Record<ProviderId, string | undefined> {
   if (IS_EMULATOR) {
@@ -160,5 +161,121 @@ export const fix = onRequest(
       return;
     }
     res.status(200).set("Content-Type", "application/json").json({ suggestedSchema: result.suggestedSchema });
+  }
+);
+
+interface FeedbackBody {
+  type: string;
+  description: string;
+  email?: string;
+  website?: string;
+  page?: string;
+}
+
+const FEEDBACK_TYPES = ["bug", "feature", "general"] as const;
+const FEEDBACK_LABEL_MAP: Record<string, string> = {
+  bug: "bug",
+  feature: "enhancement",
+  general: "feedback",
+};
+
+export const feedback = onRequest(
+  {
+    cors: IS_EMULATOR,
+    invoker: "public",
+    secrets: IS_EMULATOR ? [] : [GITHUB_PAT_SECRET],
+  },
+  async (req, res) => {
+    setCors(res);
+    if (req.method === "OPTIONS") {
+      res.status(204).end();
+      return;
+    }
+    if (req.method !== "POST") {
+      res.status(405).set("Content-Type", "application/json").json({ error: "Method not allowed" });
+      return;
+    }
+
+    let body: FeedbackBody;
+    try {
+      const raw =
+        req.body != null
+          ? typeof req.body === "string"
+            ? req.body
+            : JSON.stringify(req.body)
+          : (req.rawBody?.toString() ?? "{}");
+      body = raw ? (JSON.parse(raw) as FeedbackBody) : {} as FeedbackBody;
+    } catch {
+      res.status(400).set("Content-Type", "application/json").json({ error: "Invalid JSON body" });
+      return;
+    }
+
+    // Honeypot — silently accept to not reveal the check
+    if (body.website) {
+      res.status(200).set("Content-Type", "application/json").json({ ok: true });
+      return;
+    }
+
+    if (!body.type || !(FEEDBACK_TYPES as readonly string[]).includes(body.type)) {
+      res.status(400).set("Content-Type", "application/json").json({ error: "Invalid feedback type" });
+      return;
+    }
+    if (!body.description || typeof body.description !== "string" || body.description.trim().length < 5) {
+      res.status(400).set("Content-Type", "application/json").json({ error: "Description too short (min 5 chars)" });
+      return;
+    }
+    if (body.description.length > 5000) {
+      res.status(400).set("Content-Type", "application/json").json({ error: "Description too long (max 5000 chars)" });
+      return;
+    }
+
+    const ghToken = IS_EMULATOR ? process.env.GITHUB_PAT : GITHUB_PAT_SECRET.value();
+    if (!ghToken) {
+      res.status(500).set("Content-Type", "application/json").json({ error: "GitHub integration not configured" });
+      return;
+    }
+
+    const typeLabel = FEEDBACK_LABEL_MAP[body.type] ?? "feedback";
+    const title = `[${body.type}] ${body.description.trim().slice(0, 80)}`;
+    const issueBody = [
+      `**Type:** ${body.type}`,
+      `**Page:** ${body.page ?? "unknown"}`,
+      body.email ? `**Email:** ${body.email}` : "",
+      "",
+      "---",
+      "",
+      body.description.trim(),
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    try {
+      const ghRes = await fetch(
+        "https://api.github.com/repos/codygo-ai/structured-schema-validator/issues",
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${ghToken}`,
+            Accept: "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+          body: JSON.stringify({
+            title,
+            body: issueBody,
+            labels: [typeLabel, "user-feedback"],
+          }),
+        }
+      );
+      if (!ghRes.ok) {
+        const errText = await ghRes.text();
+        throw new Error(`GitHub API ${ghRes.status}: ${errText}`);
+      }
+      res.status(200).set("Content-Type", "application/json").json({ ok: true });
+    } catch (err) {
+      res.status(502).set("Content-Type", "application/json").json({
+        error: `Failed to create issue: ${(err as Error).message}`,
+      });
+    }
   }
 );

--- a/packages/frontend/next.config.ts
+++ b/packages/frontend/next.config.ts
@@ -9,6 +9,7 @@ const nextConfig: NextConfig = {
     return [
       { source: "/api/validate", destination: `${FUNCTIONS_EMULATOR}/validate` },
       { source: "/api/fix", destination: `${FUNCTIONS_EMULATOR}/fix` },
+      { source: "/api/feedback", destination: `${FUNCTIONS_EMULATOR}/feedback` },
     ];
   },
 };

--- a/packages/frontend/src/app/globals.css
+++ b/packages/frontend/src/app/globals.css
@@ -390,3 +390,19 @@ body {
   font-size: 0.9em;
   color: var(--ds-accent);
 }
+
+/* Feedback widget slide-in animation */
+@keyframes feedback-slide-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.feedback-slide-in {
+  animation: feedback-slide-in var(--ds-duration) ease-out;
+}

--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { FirebaseAnalytics } from "~/components/FirebaseAnalytics";
 import { GoogleOneTap } from "~/components/GoogleOneTap";
+import { BetaBanner } from "~/components/BetaBanner";
+import { FeedbackWidget } from "~/components/FeedbackWidget";
 
 const siteName = "Codygo's Strictly Structured";
 const description =
@@ -61,7 +63,9 @@ export default function RootLayout({
       <body className="min-h-screen antialiased" suppressHydrationWarning>
         <FirebaseAnalytics />
         <GoogleOneTap />
+        <BetaBanner />
         {children}
+        <FeedbackWidget />
       </body>
     </html>
   );

--- a/packages/frontend/src/components/BetaBadge.tsx
+++ b/packages/frontend/src/components/BetaBadge.tsx
@@ -1,0 +1,7 @@
+export function BetaBadge() {
+  return (
+    <span className="ml-2 inline-flex items-center rounded-full bg-accent/15 px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wider text-accent">
+      Beta
+    </span>
+  );
+}

--- a/packages/frontend/src/components/BetaBanner.tsx
+++ b/packages/frontend/src/components/BetaBanner.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "ssv-beta-banner-dismissed";
+
+function subscribe(onStoreChange: () => void) {
+  window.addEventListener("storage", onStoreChange);
+  return () => window.removeEventListener("storage", onStoreChange);
+}
+
+function getSnapshot() {
+  return localStorage.getItem(STORAGE_KEY) === null;
+}
+
+function getServerSnapshot() {
+  return false;
+}
+
+export function BetaBanner() {
+  const visible = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const handleDismiss = useCallback(() => {
+    localStorage.setItem(STORAGE_KEY, "1");
+    // Force re-render since storage event only fires cross-tab
+    window.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+  }, []);
+
+  const handleFeedbackClick = useCallback(() => {
+    window.dispatchEvent(new CustomEvent("ssv:open-feedback"));
+    handleDismiss();
+  }, [handleDismiss]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="bg-accent text-white text-sm text-center py-1.5 px-4 relative z-50">
+      <span>
+        This is an early beta &mdash; we&apos;d love your{" "}
+        <button
+          type="button"
+          onClick={handleFeedbackClick}
+          className="underline font-medium hover:opacity-80 cursor-pointer"
+        >
+          feedback
+        </button>
+        !
+      </span>
+      <button
+        type="button"
+        onClick={handleDismiss}
+        className="absolute right-3 top-1/2 -translate-y-1/2 text-white/80 hover:text-white cursor-pointer"
+        aria-label="Dismiss banner"
+      >
+        &#x2715;
+      </button>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/packages/frontend/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  FEEDBACK_TYPES,
+  FEEDBACK_TYPE_CONFIG,
+  type FeedbackType,
+  type FeedbackPayload,
+} from "./types";
+
+const GITHUB_ISSUES_URL =
+  "https://github.com/codygo-ai/structured-schema-validator/issues";
+const API_URL = "/api/feedback";
+
+type FormState = "idle" | "submitting" | "success" | "error";
+
+export function FeedbackWidget() {
+  const [open, setOpen] = useState(false);
+  const [type, setType] = useState<FeedbackType>("general");
+  const [description, setDescription] = useState("");
+  const [email, setEmail] = useState("");
+  const [honeypot, setHoneypot] = useState("");
+  const [formState, setFormState] = useState<FormState>("idle");
+  const [errorMessage, setErrorMessage] = useState("");
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Listen for custom event from BetaBanner
+  useEffect(() => {
+    const handleOpen = () => setOpen(true);
+    window.addEventListener("ssv:open-feedback", handleOpen);
+    return () => window.removeEventListener("ssv:open-feedback", handleOpen);
+  }, []);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open]);
+
+  const resetForm = useCallback(() => {
+    setType("general");
+    setDescription("");
+    setEmail("");
+    setHoneypot("");
+    setFormState("idle");
+    setErrorMessage("");
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    if (!description.trim()) return;
+    setFormState("submitting");
+
+    const payload: FeedbackPayload = {
+      type,
+      description: description.trim(),
+      email: email.trim() || undefined,
+      website: honeypot || undefined,
+      page: window.location.pathname,
+    };
+
+    try {
+      const res = await fetch(API_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        throw new Error(data.error ?? `Request failed (${res.status})`);
+      }
+      setFormState("success");
+    } catch (err) {
+      setFormState("error");
+      setErrorMessage((err as Error).message);
+    }
+  }, [type, description, email, honeypot]);
+
+  function handleClose() {
+    setOpen(false);
+    setTimeout(resetForm, 200);
+  }
+
+  const githubNewIssueUrl = `${GITHUB_ISSUES_URL}/new${
+    type === "bug"
+      ? "?template=bug_report.md"
+      : type === "feature"
+        ? "?template=feature_request.md"
+        : ""
+  }`;
+
+  return (
+    <div ref={panelRef} className="fixed bottom-5 right-5 z-50">
+      {/* Floating trigger */}
+      {!open && (
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="flex h-12 w-12 items-center justify-center rounded-full bg-accent text-white shadow-lg transition-all duration-[var(--ds-duration)] hover:scale-105 hover:bg-accent-hover cursor-pointer"
+          aria-label="Send feedback"
+          title="Send feedback"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="22"
+            height="22"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+            />
+          </svg>
+        </button>
+      )}
+
+      {/* Feedback panel */}
+      {open && (
+        <div className="w-80 rounded-lg border border-border bg-surface shadow-xl feedback-slide-in">
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-border px-4 py-3">
+            <h3 className="text-sm font-semibold text-primary">
+              Send Feedback
+            </h3>
+            <button
+              type="button"
+              onClick={handleClose}
+              className="text-muted hover:text-primary cursor-pointer"
+              aria-label="Close"
+            >
+              &#x2715;
+            </button>
+          </div>
+
+          {formState === "success" ? (
+            <div className="px-4 py-6 text-center">
+              <div className="text-3xl mb-2">&#x2705;</div>
+              <p className="text-sm font-medium text-primary">
+                Thank you for your feedback!
+              </p>
+              <p className="text-xs text-secondary mt-1">
+                We&apos;ll review it shortly.
+              </p>
+              <button
+                type="button"
+                onClick={handleClose}
+                className="mt-4 text-sm text-accent hover:underline cursor-pointer"
+              >
+                Close
+              </button>
+            </div>
+          ) : (
+            <div className="px-4 py-3 space-y-3">
+              {/* Type selector */}
+              <div className="flex gap-1.5">
+                {FEEDBACK_TYPES.map((t) => (
+                  <button
+                    key={t}
+                    type="button"
+                    onClick={() => setType(t)}
+                    className={`flex-1 rounded-md border px-2 py-1.5 text-xs font-medium transition-colors cursor-pointer ${
+                      type === t
+                        ? "border-accent bg-accent-bg text-accent"
+                        : "border-border bg-surface text-secondary hover:bg-surface-hover"
+                    }`}
+                  >
+                    {FEEDBACK_TYPE_CONFIG[t].icon}{" "}
+                    {FEEDBACK_TYPE_CONFIG[t].label}
+                  </button>
+                ))}
+              </div>
+
+              {/* Description */}
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="Tell us what's on your mind..."
+                rows={4}
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-primary placeholder:text-muted focus:border-accent focus:outline-none resize-none"
+              />
+
+              {/* Email (optional) */}
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="Email (optional, for follow-up)"
+                className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-primary placeholder:text-muted focus:border-accent focus:outline-none"
+              />
+
+              {/* Honeypot */}
+              <input
+                type="text"
+                value={honeypot}
+                onChange={(e) => setHoneypot(e.target.value)}
+                className="absolute -left-[9999px] opacity-0"
+                tabIndex={-1}
+                autoComplete="off"
+                aria-hidden="true"
+              />
+
+              {formState === "error" && (
+                <p className="text-xs text-error">{errorMessage}</p>
+              )}
+
+              {/* Submit + GitHub link */}
+              <div className="flex items-center justify-between pt-1">
+                <a
+                  href={githubNewIssueUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-muted hover:text-accent hover:underline"
+                >
+                  Or open a GitHub issue
+                </a>
+                <button
+                  type="button"
+                  onClick={handleSubmit}
+                  disabled={
+                    !description.trim() || formState === "submitting"
+                  }
+                  className="rounded-md bg-accent px-4 py-1.5 text-sm font-medium text-white hover:bg-accent-hover disabled:bg-disabled disabled:cursor-not-allowed transition-colors cursor-pointer"
+                >
+                  {formState === "submitting" ? "Sending..." : "Send"}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/FeedbackWidget/index.ts
+++ b/packages/frontend/src/components/FeedbackWidget/index.ts
@@ -1,0 +1,1 @@
+export { FeedbackWidget } from "./FeedbackWidget";

--- a/packages/frontend/src/components/FeedbackWidget/types.ts
+++ b/packages/frontend/src/components/FeedbackWidget/types.ts
@@ -1,0 +1,19 @@
+export const FEEDBACK_TYPES = ["bug", "feature", "general"] as const;
+export type FeedbackType = (typeof FEEDBACK_TYPES)[number];
+
+export const FEEDBACK_TYPE_CONFIG: Record<
+  FeedbackType,
+  { label: string; icon: string; ghLabel: string }
+> = {
+  bug: { label: "Bug Report", icon: "\u{1F41B}", ghLabel: "bug" },
+  feature: { label: "Feature Request", icon: "\u{1F4A1}", ghLabel: "enhancement" },
+  general: { label: "General Feedback", icon: "\u{1F4AC}", ghLabel: "feedback" },
+};
+
+export interface FeedbackPayload {
+  type: FeedbackType;
+  description: string;
+  email?: string;
+  website?: string;
+  page: string;
+}

--- a/packages/frontend/src/components/Header.tsx
+++ b/packages/frontend/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { BetaBadge } from "~/components/BetaBadge";
 
 export function Header() {
   return (
@@ -12,6 +13,7 @@ export function Header() {
           <span className="text-[var(--foreground)] font-semibold ml-2">
             Structured Schema Validator
           </span>
+          <BetaBadge />
         </Link>
         <div className="flex items-center gap-6">
           <Link

--- a/packages/frontend/src/components/SiteHeader.tsx
+++ b/packages/frontend/src/components/SiteHeader.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { UserAvatarMenu } from "~/components/UserAvatarMenu";
+import { BetaBadge } from "~/components/BetaBadge";
 
 export function SiteHeader({
   subtitle = true,
@@ -18,6 +19,7 @@ export function SiteHeader({
           <Link href="/" className="font-bold text-primary hover:underline">
             Strictly Structured
           </Link>
+          <BetaBadge />
           <span className="text-sm text-secondary">
             {" "}
             by{" "}


### PR DESCRIPTION
## Summary
- Adds a "BETA" pill badge to the site headers
- Adds a dismissable top banner ("early beta — we'd love your feedback!")
- Adds a floating feedback widget (bottom-right) with bug/feature/general types
- Widget submits to a new `/api/feedback` Cloud Function that creates GitHub Issues anonymously via a PAT
- Includes honeypot field for basic spam protection

## Setup required before deploy
- `firebase functions:secrets:set GITHUB_PAT`
- Create GitHub labels: `bug`, `enhancement`, `feedback`, `user-feedback`

## Test plan
- [ ] Verify beta badge renders in SiteHeader on all pages
- [ ] Verify banner shows on first visit, dismiss persists across refresh
- [ ] Verify feedback form opens, submits, and shows success state
- [ ] Verify "Or open a GitHub issue" link works
- [ ] Verify honeypot submissions are silently accepted
- [ ] Run emulator and confirm issue is created on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)